### PR TITLE
Expose library as CLI

### DIFF
--- a/bin/jsonexport.js
+++ b/bin/jsonexport.js
@@ -1,0 +1,26 @@
+#! /usr/bin/env node
+
+var jsonexport = require('../lib/index.js');
+
+var stdin = process.stdin,
+    inputChunks = [];
+
+stdin.setEncoding('utf8');
+
+stdin.on('data', function (chunk) {
+    inputChunks.push(chunk);
+});
+
+stdin.on('end', function () {
+    var input = inputChunks.join(''),
+        parsedData = JSON.parse(input);
+
+    jsonexport(parsedData, function (err, csv) {
+        if (err) {
+            console.error(err);
+            process.exit(1);
+        }
+
+        console.log(csv);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "bin": {
+      "jsonexport": "bin/jsonexport.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Cnova/jsonexport.git"


### PR DESCRIPTION
This change allows jsonexport to be used on the command line:

`echo '[{"a" : 0}, {"b": 1}]' | jsonexport`